### PR TITLE
is_setting_supported in enforcement_manager.py does the opposite of w…

### DIFF
--- a/util/enforcement_manager.py
+++ b/util/enforcement_manager.py
@@ -70,7 +70,7 @@ class EnforcementManager:
         if not self.supported_settings:
             return True
 
-        if isinstance(self.supported_settings.get(setting), List) and len(self.supported_settings.get(setting)) == 0:
+        if isinstance(self.supported_settings.get(setting), List) and len(self.supported_settings.get(setting)) != 0:
             return True
 
         if isinstance(self.supported_settings.get(setting), bool) and self.supported_settings.get(setting):


### PR DESCRIPTION
…hat it should do for type List

In enforcement_manager.py, is_setting_supported is supposed to give the list of the settings which are supported on the platform, by checking the result of system/settings/list. If an item is a boolean and set to false, it's not supported. If an item is a List and is empty, it's not supported either. If the list has values, then it is supported. However, with the existing code, an empty list for a setting will return True (supported) and a non-empty list will return False (not supported)! Changing the comparison for the len() should fix it.